### PR TITLE
feat(147102): adiciona teste unitários para importação de habilitados

### DIFF
--- a/importa_arquivos/tests/services/test_api_concursos.py
+++ b/importa_arquivos/tests/services/test_api_concursos.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+from importa_arquivos.services.api_concursos import ApiConcursosService
+from importa_arquivos.services.exceptions import CargoConcursoInvalidoException
+
+
+def _make_service():
+    return ApiConcursosService(base_url='http://concursos-api', timeout_seconds=5)
+
+
+def test_obter_codigos_cargo_sucesso():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        'uuid': 'abc',
+        'nome': 'Concurso X',
+        'cargos': [
+            {'uuid': '1', 'nome': 'Cargo A', 'codigo': 10},
+            {'uuid': '2', 'nome': 'Cargo B', 'codigo': 20},
+        ],
+    }
+    with patch('importa_arquivos.services.api_concursos.requests.get', return_value=mock_resp):
+        codigos = _make_service().obter_codigos_cargo_do_concurso('uuid-concurso')
+    assert codigos == {10, 20}
+
+
+def test_obter_codigos_cargo_sem_cargos():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {'uuid': 'abc', 'cargos': []}
+    with patch('importa_arquivos.services.api_concursos.requests.get', return_value=mock_resp):
+        codigos = _make_service().obter_codigos_cargo_do_concurso('uuid-concurso')
+    assert codigos == set()
+
+
+def test_obter_codigos_cargo_404_lanca_excecao():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    with patch('importa_arquivos.services.api_concursos.requests.get', return_value=mock_resp):
+        with pytest.raises(CargoConcursoInvalidoException) as exc:
+            _make_service().obter_codigos_cargo_do_concurso('uuid-invalido')
+    assert 'concurso' in exc.value.mensagem.lower()
+
+
+def test_obter_codigos_cargo_erro_conexao_lanca_excecao():
+    from requests.exceptions import RequestException
+    with patch('importa_arquivos.services.api_concursos.requests.get', side_effect=RequestException('timeout')):
+        with pytest.raises(CargoConcursoInvalidoException) as exc:
+            _make_service().obter_codigos_cargo_do_concurso('uuid-concurso')
+    assert 'indisponível' in exc.value.mensagem.lower()
+
+
+def test_obter_codigos_cargo_5xx_lanca_excecao():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+    with patch('importa_arquivos.services.api_concursos.requests.get', return_value=mock_resp):
+        with pytest.raises(CargoConcursoInvalidoException):
+            _make_service().obter_codigos_cargo_do_concurso('uuid-concurso')

--- a/importa_arquivos/tests/services/test_validacao_habilitados.py
+++ b/importa_arquivos/tests/services/test_validacao_habilitados.py
@@ -5,9 +5,22 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from importa_arquivos.services.validacao_habilitados import validar_csv_habilitados
 from importa_arquivos.services.exceptions import LayoutNaoConfiguradoException, ColunaCSVInvalidaException
 from importa_arquivos.models import LayoutArquivoImportacao
+from unittest.mock import patch, MagicMock
+from importa_arquivos.services.exceptions import CargoConcursoInvalidoException
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def layout_com_cargo():
+    estrutura = [
+        {'coluna': 'Inscricao', 'campo_payload': 'codigo_inscricao', 'obrigatorio': '1'},
+        {'coluna': 'Nome', 'campo_payload': 'nome', 'obrigatorio': '1'},
+        {'coluna': 'CPF', 'campo_payload': 'cpf', 'obrigatorio': '1'},
+        {'coluna': 'Codigo_do_Cargo', 'campo_payload': 'codigo_cargo', 'obrigatorio': '1'},
+    ]
+    LayoutArquivoImportacao.objects.create(tipo='HABILITADOS', estrutura=estrutura)
 
 
 def test_validar_csv_habilitados_sucesso(layout_habilitados):
@@ -237,24 +250,6 @@ def test_validar_codigo_cargo_identificado_por_campo_payload():
     assert any('não possui relação' in m for m in erros[2])
 
 
-# ---------------------------------------------------------------------------
-# Testes de integração: validar_csv_habilitados com Codigo_do_Cargo
-# ---------------------------------------------------------------------------
-
-from unittest.mock import patch, MagicMock
-from importa_arquivos.services.exceptions import CargoConcursoInvalidoException
-
-
-def _criar_layout_com_cargo():
-    estrutura = [
-        {'coluna': 'Inscricao', 'campo_payload': 'codigo_inscricao', 'obrigatorio': '1'},
-        {'coluna': 'Nome', 'campo_payload': 'nome', 'obrigatorio': '1'},
-        {'coluna': 'CPF', 'campo_payload': 'cpf', 'obrigatorio': '1'},
-        {'coluna': 'Codigo_do_Cargo', 'campo_payload': 'codigo_cargo', 'obrigatorio': '1'},
-    ]
-    LayoutArquivoImportacao.objects.create(tipo='HABILITADOS', estrutura=estrutura)
-
-
 def _mock_concursos_service(codigos: set):
     mock_service = MagicMock()
     mock_service.obter_codigos_cargo_do_concurso.return_value = codigos
@@ -273,8 +268,7 @@ class _FakeImportacaoObj:
 
 
 @pytest.mark.django_db
-def test_validar_csv_habilitados_codigo_cargo_valido():
-    _criar_layout_com_cargo()
+def test_validar_csv_habilitados_codigo_cargo_valido(layout_com_cargo):
     csv_text = (
         "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
         "1,Fulano,39053344705,10\n"
@@ -288,8 +282,7 @@ def test_validar_csv_habilitados_codigo_cargo_valido():
 
 
 @pytest.mark.django_db
-def test_validar_csv_habilitados_codigo_cargo_vazio_lanca_excecao():
-    _criar_layout_com_cargo()
+def test_validar_csv_habilitados_codigo_cargo_vazio_lanca_excecao(layout_com_cargo):
     csv_text = (
         "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
         "1,Fulano,39053344705,\n"
@@ -304,8 +297,7 @@ def test_validar_csv_habilitados_codigo_cargo_vazio_lanca_excecao():
 
 
 @pytest.mark.django_db
-def test_validar_csv_habilitados_codigo_cargo_sem_relacao_lanca_excecao():
-    _criar_layout_com_cargo()
+def test_validar_csv_habilitados_codigo_cargo_sem_relacao_lanca_excecao(layout_com_cargo):
     csv_text = (
         "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
         "1,Fulano,39053344705,999\n"
@@ -322,8 +314,7 @@ def test_validar_csv_habilitados_codigo_cargo_sem_relacao_lanca_excecao():
 
 
 @pytest.mark.django_db
-def test_validar_csv_habilitados_multiplos_cargos_validos():
-    _criar_layout_com_cargo()
+def test_validar_csv_habilitados_multiplos_cargos_validos(layout_com_cargo):
     csv_text = (
         "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
         "1,Fulano,39053344705,10\n"
@@ -338,8 +329,7 @@ def test_validar_csv_habilitados_multiplos_cargos_validos():
 
 
 @pytest.mark.django_db
-def test_validar_csv_habilitados_api_concursos_indisponivel_lanca_excecao():
-    _criar_layout_com_cargo()
+def test_validar_csv_habilitados_api_concursos_indisponivel_lanca_excecao(layout_com_cargo):
     csv_text = (
         "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
         "1,Fulano,39053344705,10\n"

--- a/importa_arquivos/tests/services/test_validacao_habilitados.py
+++ b/importa_arquivos/tests/services/test_validacao_habilitados.py
@@ -134,3 +134,227 @@ def test_email_duplicado_com_cpfs_diferentes_erro_mensagem_linhas_divergentes():
     detalhes = exc.value.detalhes
     assert 'Linha 3' in detalhes
     assert 'Email duplicado. CPF 17888214088 com o mesmo email que o CPF 39053344705' in detalhes
+
+
+# ---------------------------------------------------------------------------
+# Testes unitários de _validar_codigo_cargo
+# ---------------------------------------------------------------------------
+
+from importa_arquivos.services.validacao_habilitados import _validar_codigo_cargo
+
+
+COLUNAS_COM_CARGO = {
+    'email_col': None,
+    'cpf_col': None,
+    'dn_col': None,
+    'cargo_col': 'Codigo_do_Cargo',
+    'obrigatorias': ['Codigo_do_Cargo', 'Nome'],
+}
+
+COLUNAS_SEM_CARGO = {
+    'email_col': None,
+    'cpf_col': None,
+    'dn_col': None,
+    'cargo_col': None,
+    'obrigatorias': ['Nome'],
+}
+
+
+def test_validar_codigo_cargo_coluna_ausente_no_layout_retorna_vazio():
+    registros = [{'Nome': 'Fulano'}]
+    result = _validar_codigo_cargo(COLUNAS_SEM_CARGO, registros, {10, 20})
+    assert result == {}
+
+
+def test_validar_codigo_cargo_vazio_gera_erro():
+    registros = [{'Codigo_do_Cargo': '', 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 in erros
+    assert any('não pode estar em branco' in m for m in erros[2])
+
+
+def test_validar_codigo_cargo_none_gera_erro():
+    registros = [{'Codigo_do_Cargo': None, 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 in erros
+    assert any('não pode estar em branco' in m for m in erros[2])
+
+
+def test_validar_codigo_cargo_nao_inteiro_gera_erro():
+    registros = [{'Codigo_do_Cargo': 'ABC', 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 in erros
+    assert any('número inteiro válido' in m for m in erros[2])
+
+
+def test_validar_codigo_cargo_decimal_gera_erro():
+    registros = [{'Codigo_do_Cargo': '10.5', 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 in erros
+    assert any('número inteiro válido' in m for m in erros[2])
+
+
+def test_validar_codigo_cargo_nao_pertence_ao_concurso_gera_erro():
+    registros = [{'Codigo_do_Cargo': '99', 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 in erros
+    assert any('não possui relação com o concurso selecionado' in m for m in erros[2])
+    assert any('99' in m for m in erros[2])
+    assert any('Códigos válidos: 10, 20' in m for m in erros[2])
+
+
+def test_validar_codigo_cargo_valido_sem_erro():
+    registros = [{'Codigo_do_Cargo': '10', 'Nome': 'Fulano'}]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert erros == {}
+
+
+def test_validar_codigo_cargo_multiplas_linhas_erros_distintos():
+    registros = [
+        {'Codigo_do_Cargo': '10', 'Nome': 'A'},   # válido → linha 2
+        {'Codigo_do_Cargo': '', 'Nome': 'B'},      # vazio → linha 3
+        {'Codigo_do_Cargo': 'XYZ', 'Nome': 'C'},  # não inteiro → linha 4
+        {'Codigo_do_Cargo': '99', 'Nome': 'D'},   # não pertence → linha 5
+    ]
+    erros = _validar_codigo_cargo(COLUNAS_COM_CARGO, registros, {10, 20})
+    assert 2 not in erros
+    assert 3 in erros and any('não pode estar em branco' in m for m in erros[3])
+    assert 4 in erros and any('número inteiro válido' in m for m in erros[4])
+    assert 5 in erros and any('não possui relação' in m for m in erros[5])
+
+
+def test_validar_codigo_cargo_identificado_por_campo_payload():
+    colunas = {
+        'email_col': None,
+        'cpf_col': None,
+        'dn_col': None,
+        'cargo_col': 'CodCargo',
+        'obrigatorias': ['CodCargo'],
+    }
+    registros = [{'CodCargo': '99'}]
+    erros = _validar_codigo_cargo(colunas, registros, {10, 20})
+    assert 2 in erros
+    assert any('não possui relação' in m for m in erros[2])
+
+
+# ---------------------------------------------------------------------------
+# Testes de integração: validar_csv_habilitados com Codigo_do_Cargo
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch, MagicMock
+from importa_arquivos.services.exceptions import CargoConcursoInvalidoException
+
+
+def _criar_layout_com_cargo():
+    estrutura = [
+        {'coluna': 'Inscricao', 'campo_payload': 'codigo_inscricao', 'obrigatorio': '1'},
+        {'coluna': 'Nome', 'campo_payload': 'nome', 'obrigatorio': '1'},
+        {'coluna': 'CPF', 'campo_payload': 'cpf', 'obrigatorio': '1'},
+        {'coluna': 'Codigo_do_Cargo', 'campo_payload': 'codigo_cargo', 'obrigatorio': '1'},
+    ]
+    LayoutArquivoImportacao.objects.create(tipo='HABILITADOS', estrutura=estrutura)
+
+
+def _mock_concursos_service(codigos: set):
+    mock_service = MagicMock()
+    mock_service.obter_codigos_cargo_do_concurso.return_value = codigos
+    return patch(
+        'importa_arquivos.services.validacao_habilitados.ApiConcursosService',
+        return_value=mock_service,
+    )
+
+
+class _FakeImportacaoObj:
+    concurso_uuid = 'uuid-concurso-123'
+    status = 'PENDENTE'
+
+    def save(self, **kwargs):
+        pass
+
+
+@pytest.mark.django_db
+def test_validar_csv_habilitados_codigo_cargo_valido():
+    _criar_layout_com_cargo()
+    csv_text = (
+        "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
+        "1,Fulano,39053344705,10\n"
+    )
+    with _mock_concursos_service({10, 20}):
+        registros, _ = validar_csv_habilitados(
+            _csv_bytes(csv_text),
+            importacao_obj=_FakeImportacaoObj(),
+        )
+    assert len(registros) == 1
+
+
+@pytest.mark.django_db
+def test_validar_csv_habilitados_codigo_cargo_vazio_lanca_excecao():
+    _criar_layout_com_cargo()
+    csv_text = (
+        "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
+        "1,Fulano,39053344705,\n"
+    )
+    with _mock_concursos_service({10, 20}):
+        with pytest.raises(ColunaCSVInvalidaException) as exc:
+            validar_csv_habilitados(
+                _csv_bytes(csv_text),
+                importacao_obj=_FakeImportacaoObj(),
+            )
+    assert 'não pode estar em branco' in exc.value.detalhes
+
+
+@pytest.mark.django_db
+def test_validar_csv_habilitados_codigo_cargo_sem_relacao_lanca_excecao():
+    _criar_layout_com_cargo()
+    csv_text = (
+        "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
+        "1,Fulano,39053344705,999\n"
+    )
+    with _mock_concursos_service({10, 20}):
+        with pytest.raises(ColunaCSVInvalidaException) as exc:
+            validar_csv_habilitados(
+                _csv_bytes(csv_text),
+                importacao_obj=_FakeImportacaoObj(),
+            )
+    assert 'não possui relação com o concurso selecionado' in exc.value.detalhes
+    assert '999' in exc.value.detalhes
+    assert 'Códigos válidos' in exc.value.detalhes
+
+
+@pytest.mark.django_db
+def test_validar_csv_habilitados_multiplos_cargos_validos():
+    _criar_layout_com_cargo()
+    csv_text = (
+        "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
+        "1,Fulano,39053344705,10\n"
+        "2,Ciclano,17888214088,20\n"
+    )
+    with _mock_concursos_service({10, 20}):
+        registros, _ = validar_csv_habilitados(
+            _csv_bytes(csv_text),
+            importacao_obj=_FakeImportacaoObj(),
+        )
+    assert len(registros) == 2
+
+
+@pytest.mark.django_db
+def test_validar_csv_habilitados_api_concursos_indisponivel_lanca_excecao():
+    _criar_layout_com_cargo()
+    csv_text = (
+        "Inscricao,Nome,CPF,Codigo_do_Cargo\n"
+        "1,Fulano,39053344705,10\n"
+    )
+    mock_service = MagicMock()
+    mock_service.obter_codigos_cargo_do_concurso.side_effect = CargoConcursoInvalidoException(
+        mensagem='Serviço de concursos indisponível.',
+        detalhes='timeout',
+    )
+    with patch(
+        'importa_arquivos.services.validacao_habilitados.ApiConcursosService',
+        return_value=mock_service,
+    ):
+        with pytest.raises(CargoConcursoInvalidoException):
+            validar_csv_habilitados(
+                _csv_bytes(csv_text),
+                importacao_obj=_FakeImportacaoObj(),
+            )


### PR DESCRIPTION
Este PR adiciona testes unitários para as novas validações de importação de arquivos e adequação a fatoração das validações de importação.

**Principais mudanças:**
1. Cobertura de testes unitários e de integração para os novos cenários (sucesso e falha)

[AB#147102](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147102)
[AB#147001](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147001)